### PR TITLE
Fix bug in plotting barelep-only observables

### DIFF
--- a/Templates/config.kdlong
+++ b/Templates/config.kdlong
@@ -1,0 +1,9 @@
+[Setup]
+user = kdlong
+analysis = WZ
+dataset_manager_path = /afs/hep.wisc.edu/home/%(user)s/work 
+combine_path = %(dataset_manager_path)s/HiggsCombine/CMSSW_8_1_0/src/HiggsAnalysis/CombinedLimit
+output_path = /nfs_scratch/%(user)s/%(analysis)sAnalysisData
+fakeRate_output = %(output_path)s/FakesRates
+hist_output = %(output_path)s/HistFiles
+combine_output = %(output_path)s/CombineData

--- a/Templates/config.kelong
+++ b/Templates/config.kelong
@@ -1,7 +1,7 @@
 [Setup]
 user = kelong
 analysis = ZGen
-dataset_manager_path = /afs/cern.ch/user/k/%(user)s/work 
+dataset_manager_path = ~/work 
 dataset_manager_name = AnalysisDatasetManager
 combine_path = %(dataset_manager_path)s/HiggsCombine/CMSSW_8_1_0/src/HiggsAnalysis/CombinedLimit
 output_path = /eos/user/k/%(user)s/%(analysis)sAnalysisData

--- a/Utilities/python/ConfigureJobs.py
+++ b/Utilities/python/ConfigureJobs.py
@@ -83,7 +83,7 @@ def getManagerPath():
     if "dataset_manager_path" not in config['Setup']:
         raise ValueError("dataset_manager_path not specified in config file %s"
                         % config_name)
-    return config['Setup']['dataset_manager_path'] + "/"
+    return os.path.expanduser(config['Setup']['dataset_manager_path']) + "/"
 
 def getCombinePath():
     config = configparser.ConfigParser()

--- a/src/WGenSelector.cc
+++ b/src/WGenSelector.cc
@@ -343,8 +343,11 @@ void WGenSelector::FillHistogramsByName(Long64_t entry, std::string& toAppend, S
    if (variation.first == BareLeptons) {
        //ponerse las pilas, the (variation.first == BareLeptons) refraining the histograms to fill 
         ratio_mass /= wCand.mass();
-        SafeHistFill(histMap1D_, "Ratio_Wmass", channel_, variation.first,  ratio_mass, weight);      
-        SafeHistFill(histMap1D_, concatenateNames("nGammaAssoc",toAppend), channel_, variation.first, photons.size(), weight);
+        // Call the channel central just to avoid appending the name "barelep".
+        // These histograms should only be built for the barelepton case, should be understood that they always refer 
+        // to the barlep channel implicitly
+        SafeHistFill(histMap1D_, "Ratio_Wmass", channel_, Central,  ratio_mass, weight);      
+        SafeHistFill(histMap1D_, concatenateNames("nGammaAssoc",toAppend), channel_, Central, photons.size(), weight);
 
         auto compareByPt = [](const reco::GenParticle& a, const reco::GenParticle& b) { return a.pt() < b.pt(); };
         auto compareByDRLead = [lep] (const reco::GenParticle& a, const reco::GenParticle& b) {
@@ -356,9 +359,9 @@ void WGenSelector::FillHistogramsByName(Long64_t entry, std::string& toAppend, S
                
         
 
-        SafeHistFill(histMap1D_, "dRlgamma_minassoc", channel_, variation.first, photons.size() > 0 ? reco::deltaR(*gclose, lep) : 0., weight);
-        SafeHistFill(histMap1D_, "dRlgamma_maxptassoc", channel_, variation.first, photons.size() > 0 ? reco::deltaR(*maxPtg, lep) : 0., weight);
-        SafeHistFill(histMap1D_, "ptg_closeassoc", channel_, variation.first, photons.size() > 0 ? gclose->pt() : 0., weight);
-        SafeHistFill(histMap1D_, "ptgmax_assoc", channel_, variation.first, photons.size() > 0 ? maxPtg->pt() : 0., weight);
+        SafeHistFill(histMap1D_, "dRlgamma_minassoc", channel_, Central, photons.size() > 0 ? reco::deltaR(*gclose, lep) : 0., weight);
+        SafeHistFill(histMap1D_, "dRlgamma_maxptassoc", channel_, Central, photons.size() > 0 ? reco::deltaR(*maxPtg, lep) : 0., weight);
+        SafeHistFill(histMap1D_, "ptg_closeassoc", channel_, Central, photons.size() > 0 ? gclose->pt() : 0., weight);
+        SafeHistFill(histMap1D_, "ptgmax_assoc", channel_, Central, photons.size() > 0 ? maxPtg->pt() : 0., weight);
     }
 }


### PR DESCRIPTION
The plots weren't filling because they were not considered for variations (defined by the systhists_ variable). Since we only want this to fill once, the easiest solution is to just treat the bareleptons as the central variation in this case. The result is that you will have a hist named Ratio_Wmass, which is for bareleptons, rather than Ratio_Wmass_barlep.

Sorry this was a somewhat nasty issue that I didn't anticipate. This also fixes the filling of the other histograms.